### PR TITLE
fix primitive type array args type

### DIFF
--- a/libs/encode.js
+++ b/libs/encode.js
@@ -59,7 +59,9 @@ Encode.prototype._argsType = function (args) {
     type = args[i]['$class'];
 
     if (type.charAt(0) === '[') {
-      parameterTypes += '[L' + type.slice(1).replace(/\./gi, '/') + ';';
+      parameterTypes += ~type.indexOf('.')
+        ? '[L' + type.slice(1).replace(/\./gi, '/') + ';'
+        : '[' + typeRef[type.slice(1)];
     } else {
       parameterTypes += type && ~type.indexOf('.')
         ? 'L' + type.replace(/\./gi, '/') + ';'


### PR DESCRIPTION
when $class is primitive array type, **[int** e.g., **parameterTypes** should += **[I**