### PR TITLE
add default.version support

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,9 @@ class Yoke extends EventEmitter {
       for (let i = 0; i < size; i++) {
         const provider = url.parse(decodeURIComponent(children[i]));
         const queryObj = qs.parse(provider.query);
+        if (!queryObj.version && queryObj['default.version']) {
+          queryObj.version = queryObj['default.version']
+        }
         if (
           queryObj.version === depVal.version &&
           queryObj.group === depVal.group &&


### PR DESCRIPTION
dubbo 服务指定版本有两种方式

```xml
<!-- 统一指定 -->
<dubbo:provider loadbalance="leastactive" delay="-1" version="1.0.0"/>
<dubbo:service interface="top.crazyman.dubbo.service.CommonService" ref="commonService"/>
```

```xml
<!-- 单独指定 -->
<dubbo:provider loadbalance="leastactive" delay="-1"/>
<dubbo:service interface="top.crazyman.dubbo.service.CommonService" ref="commonService"  version="1.0.0"/>
```

在统一指定版本时，向zookeeper中注册服务生成的url参数中没有version, 取而代之的是default.version, 如：`dubbo://10.0.75.1:20880/top.crazyman.dubbo.service.CommonService?anyhost=true&application=dubbo-learn-provider&default.delay=-1&default.loadbalance=leastactive&default.version=1.0.0&delay=-1&dubbo=2.6.3&environment=product&generic=false&interface=top.crazyman.dubbo.service.CommonService&methods=getCurrentDate&pid=15440&side=provider&timestamp=1541501405883&uptime=1541501405931"` 

在index.js文件resolveService方法中，在匹配对应服务提供者时，是直接通过queryObj.version来判断的，这里会造成匹配不到正确的服务提供者。
```js
for (let i = 0; i < size; i++) {
    const provider = url.parse(decodeURIComponent(children[i]));
    const queryObj = qs.parse(provider.query);
    if (
        queryObj.version === depVal.version &&
        queryObj.group === depVal.group &&
        provider.protocol === "dubbo:"
    ) {
        providers.push(provider);
    }
}
```